### PR TITLE
NIX-1152 build on debian 12.8.0 which uses gcc 12.2.0. We need to tel…

### DIFF
--- a/src/cpDatum.cpp
+++ b/src/cpDatum.cpp
@@ -992,7 +992,13 @@ bool Datum::Find(Attrib_t Type, Attribs_t::iterator &It)
 // find a datum with the specified name
 Datum::Data_t::const_iterator Datum::Find(String const &Name) const
 {
-    return Find(Name);
+    /*
+     *  Avoid a compiler ambiguity issue on Debian 12 with gcc 12.2 by ensuring 
+     *  the non-const Find() is called, thus avoiding an infinite recursion loop.
+     */
+
+    Data_t::iterator i = const_cast<Datum *>(this)->Find(Name);
+    return static_cast<Data_t::const_iterator>(i);
 }
 
 


### PR DESCRIPTION
 I am  building on debian 12.8.0, which uses a newer gcc 12.2.0(Debian 12.2.0-14) . Older compiler on AlmaLinux9 is 11.5.0 and it has no problems with the original code.  I run into a compiler method ambiguity issue in cpDatum.cpp where the method Find(String const &Name) is overloaded and the second listed Find method in first code snippet (below) is supposed to call the first. With the gcc 12.2 compiler, this becomes ambiguous and thinks incorrectly that the second function is calling itself, generating an infinite recursion error. 
     error: infinite recursion detected [-Werror=infinite-recursion]

```
// find a datum with the specified name
Datum::Data_t::iterator Datum::Find(String const &Name)
{
    Data_t::iterator i = m_Datums.begin();

    while (i != m_Datums.end())
    {
        if (i->NameGet() == Name)
        {
            break;
        }

        ++i;
    }
    return i;
}

// find a datum with the specified name
Datum::Data_t::const_iterator Datum::Find(String const &Name) const
{
   return(Find(Name);   // Error: Infinite recursion.
}

```
What is lacking is casting sufficient to prevent ambiguity, specifically ensuring that the second function calls the non-const method of Find. This second Find method becomes the following:

```
// find a datum with the specified name
Datum::Data_t::const_iterator Datum::Find(String const &Name) const
{
    /*
     *  Avoid a compiler ambiguity issue on Debian 12 with gcc 12.2 by ensuring 
     *  the non-const Find() is called, thus avoiding an infinite recursion loop.
     */

    Data_t::iterator i = const_cast<Datum *>(this)->Find(Name);
    return static_cast<Data_t::const_iterator>(i);
}
```
